### PR TITLE
Bump actions/setup-python from v5 to v6 (Node.js 24)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     required: false
     default: ''
   python-version:
-    description: 'If set, runs actions/setup-python@v5 with this version before installing xonsh. Leave empty to use the Python already on PATH.'
+    description: 'If set, runs actions/setup-python@v6 with this version before installing xonsh. Leave empty to use the Python already on PATH.'
     required: false
     default: ''
   extras:
@@ -36,7 +36,7 @@ runs:
   steps:
     - name: Set up Python
       if: inputs.python-version != ''
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 


### PR DESCRIPTION
## Summary
- Bumps the pinned `actions/setup-python` from `v5` to `v6` so this action stops triggering the Node.js 20 deprecation warning.
- v6 is the first major release that ships on Node.js 24. The input/output API is identical to v5 (verified against the [v6 `action.yml`](https://github.com/actions/setup-python/blob/v6/action.yml) — `python-version` and the rest of the inputs we use are unchanged).
- Updates the `python-version` input description to match.

## Why now
GitHub will force Node.js 20 actions to Node.js 24 by default on **2026-06-02** and remove Node.js 20 from runners entirely on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Consumers of `xonsh/actions@v1` are currently surfacing a deprecation warning sourced from the pinned `setup-python@v5`.

## Test plan
- [ ] CI on this PR runs `setup-python@v6` and installs xonsh successfully.