### PR TITLE
Bump test workflow actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/test-pip-xontrib.yml
+++ b/.github/workflows/test-pip-xontrib.yml
@@ -26,9 +26,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '${{ matrix.python-version }}'
         cache: pip

--- a/.github/workflows/test-poetry-xontrib.yml
+++ b/.github/workflows/test-poetry-xontrib.yml
@@ -22,14 +22,14 @@ jobs:
           - "3.12"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Install poetry
       run: pipx install poetry
     - name: Lock dependencies
       if: hashFiles('poetry.lock') == ''
       run: poetry lock
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '${{ matrix.python-version }}'
         cache: poetry

--- a/.github/workflows/test-setup-xonsh.yml
+++ b/.github/workflows/test-setup-xonsh.yml
@@ -20,7 +20,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./
         id: xonsh
@@ -44,7 +44,7 @@ jobs:
   with-python-version:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./
         with:
           python-version: '3.13'
@@ -57,7 +57,7 @@ jobs:
   with-extras-and-xontrib:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./
         with:
           extras: 'ptk'
@@ -75,7 +75,7 @@ jobs:
       run:
         shell: 'xonsh {0}'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install xonsh
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
Bumps the action versions referenced from this repo's own CI workflows so they stop emitting the Node.js 20 deprecation warning:
- `actions/checkout@v4` → `@v5` (6 occurrences across all three test workflows)
- `actions/setup-python@v5` → `@v6` (in `test-pip-xontrib.yml` and `test-poetry-xontrib.yml`)

Both `@v5` of checkout and `@v6` of setup-python are the first majors that ship on Node.js 24. Inputs/outputs we use are unchanged.

## Why now
GitHub will force Node.js 20 actions to Node.js 24 by default on **2026-06-02** and remove Node.js 20 from runners entirely on **2026-09-16** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). After PR #4 cleared the warning inside `action.yml`, this repo's own CI runs (e.g. https://github.com/xonsh/actions/actions/runs/25062681987) were the only remaining source of the warning.

## Test plan
- [ ] `ci-test-setup-xonsh` passes on Linux/macOS/Windows after the bump.